### PR TITLE
Use standardized license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP library to read byte-level data from files",
     "type": "library",
     "homepage": "http://www.tecnick.com",
-    "license": "GNU-LGPL v3",
+    "license": "LGPL-3.0",
     "keywords": ["tc-lib-file", "file", "byte", "bit", "read", "short", "long", "double"],
     "authors": [
         {


### PR DESCRIPTION
SPDX has standardized the license identifiers to avoid confusions and allow tool-assisted license checks
https://spdx.org/licenses/
