### PR TITLE
Make Composer scripts work on Windows (cmd.exe) without changing Unix…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,13 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "sort-packages": true
     },
     "require-dev": {
         "pdepend/pdepend": "^2.16",
-        "phpunit/phpunit": "^13.1 || ^12.5 || ^11.5",
-        "phpcompatibility/php-compatibility": "^10.0.0@dev"
+        "phpcompatibility/php-compatibility": "^10.0.0@dev",
+        "phpunit/phpunit": "^11.5 || ^12.5 || ^13.1"
     },
     "autoload": {
         "psr-4": {
@@ -59,9 +60,16 @@
         "source": "https://github.com/tecnickcom/tc-lib-file"
     },
     "scripts": {
-        "test": "XDEBUG_MODE=coverage ./vendor/bin/phpunit --stderr test",
-        "cs-check": "./vendor/bin/mago --config ./mago.src.toml lint src && ./vendor/bin/mago --config ./mago.test.toml lint test",
-        "cs-fix": "./vendor/bin/mago fmt src test",
-        "analyse": "./vendor/bin/mago --config ./mago.src.toml analyze src && ./vendor/bin/mago --config ./mago.test.toml analyze test"
+        "test": "@php -d xdebug.mode=coverage vendor/bin/phpunit --stderr test",
+
+        "analyse": ["@analyse:src", "@analyse:test"],
+        "analyse:src": "mago --config mago.src.toml analyze src",
+        "analyse:test": "mago --config mago.test.toml analyze test",
+
+        "cs-check": ["@cs-check:src", "@cs-check:test"],
+        "cs-check:src": "mago --config mago.src.toml lint src",
+        "cs-check:test": "mago --config mago.test.toml lint test",
+
+        "cs-fix": "mago fmt src test"
     }
 }


### PR DESCRIPTION
… behavior

 - Drop ./vendor/bin
 - Convert '&&' chained commands to use Composer @ script arrays
 - Use @php (php version composer is running on) with -d xdebug.mode=coverage to set XDEBUG mode

# Description
These changes let "composer analyse" and "composer cs-check" work on Windows without changing Unix behavior.

...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [ ] Testing.
