### PR TITLE
Byte: Optimize read speed while minimizing memory usage

### DIFF
--- a/src/Byte.php
+++ b/src/Byte.php
@@ -18,6 +18,9 @@ declare(strict_types=1);
 
 namespace Com\Tecnick\File;
 
+use Com\Tecnick\File\Exception as FileException;
+use RangeException;
+
 /**
  * Com\Tecnick\File\Byte
  *
@@ -31,41 +34,43 @@ namespace Com\Tecnick\File;
  * @license   https://www.gnu.org/copyleft/lesser.html GNU-LGPL v3 (see LICENSE.TXT)
  * @link      https://github.com/tecnickcom/tc-lib-file
  */
-class Byte
+readonly class Byte
 {
     /**
-     * Initialize a new string to be processed
+     * Length of the binary string in bytes.
+     */
+    private int $length;
+
+    /**
+     * Initialize a new string to be processed.
      *
-     * @param string $str String from where to extract values
+     * Values are read in place via \ord() + bitwise math: no per-read unpack()
+     * call and no byte-table copy, so memory stays at the size of the string.
+     *
+     * @param string $str String (binary) from where to extract values
      */
     public function __construct(
         /**
-         * String to process
+         * Binary string to process
          */
         protected string $str,
-    ) {}
+    ) {
+        $this->length = \strlen($str);
+    }
 
     /**
-     * Verify that an offset + length read is within the string bounds.
+     * Throw for a read that failed its bounds check.
      *
      * @param int $offset Read start position.
-     * @param int $length Number of bytes to read.
+     * @param int $length Number of bytes requested.
      *
-     * @throws \RangeException if the read exceeds the string length.
+     * @throws RangeException always.
      */
-    private function checkBounds(int $offset, int $length): void
+    private function throwOutOfBounds(int $offset, int $length): never
     {
-        if (($offset + $length) > \strlen($this->str)) {
-            throw new \RangeException(
-                'Out-of-bounds read at offset '
-                . $offset
-                . ' (length '
-                . $length
-                . ', string length '
-                . \strlen($this->str)
-                . ')',
-            );
-        }
+        throw new RangeException(
+            "Out-of-bounds read at offset {$offset} (length {$length}, string length {$this->length})",
+        );
     }
 
     /**
@@ -75,14 +80,15 @@ class Byte
      *
      * @return int 8 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getByte(int $offset): int
     {
-        $this->checkBounds($offset, 1);
-        $val = \unpack('Ci', \substr($this->str, $offset, 1));
-        $read = $val !== false ? $val['i'] ?? null : null;
-        return \is_int($read) ? $read & 0xFF : 0;
+        if ($offset < 0 || $offset >= $this->length) {
+            $this->throwOutOfBounds($offset, 1);
+        }
+
+        return \ord($this->str[$offset]);
     }
 
     /**
@@ -92,14 +98,15 @@ class Byte
      *
      * @return int 16 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getUShort(int $offset): int
     {
-        $this->checkBounds($offset, 2);
-        $val = \unpack('ni', \substr($this->str, $offset, 2));
-        $read = $val !== false ? $val['i'] ?? null : null;
-        return \is_int($read) ? $read & 0xFFFF : 0;
+        if ($offset < 0 || $offset > $this->length - 2) {
+            $this->throwOutOfBounds($offset, 2);
+        }
+
+        return (\ord($this->str[$offset]) << 8) | \ord($this->str[$offset + 1]);
     }
 
     /**
@@ -109,12 +116,18 @@ class Byte
      *
      * @return int 16 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getShort(int $offset): int
     {
-        $val = $this->getUShort($offset);
-        // convert to signed 16-bit (two's complement)
+        if ($offset < 0 || $offset > $this->length - 2) {
+            $this->throwOutOfBounds($offset, 2);
+        }
+
+        // The uint16 value
+        $val = (\ord($this->str[$offset]) << 8) | \ord($this->str[$offset + 1]);
+
+        // Use bitwise two's complement uint16 to int16 formula
         return ($val ^ 0x8000) - 0x8000;
     }
 
@@ -126,11 +139,15 @@ class Byte
      *
      * @return int 16 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getUFWord(int $offset): int
     {
-        return $this->getUShort($offset);
+        if ($offset < 0 || $offset > $this->length - 2) {
+            $this->throwOutOfBounds($offset, 2);
+        }
+
+        return (\ord($this->str[$offset]) << 8) | \ord($this->str[$offset + 1]);
     }
 
     /**
@@ -141,11 +158,19 @@ class Byte
      *
      * @return int 16 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getFWord(int $offset): int
     {
-        return $this->getShort($offset);
+        if ($offset < 0 || $offset > $this->length - 2) {
+            $this->throwOutOfBounds($offset, 2);
+        }
+
+        // The uint16 value
+        $val = (\ord($this->str[$offset]) << 8) | \ord($this->str[$offset + 1]);
+
+        // Use bitwise two's complement uint16 to int16 formula
+        return ($val ^ 0x8000) - 0x8000;
     }
 
     /**
@@ -155,14 +180,18 @@ class Byte
      *
      * @return int 32 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getULong(int $offset): int
     {
-        $this->checkBounds($offset, 4);
-        $val = \unpack('Ni', \substr($this->str, $offset, 4));
-        $read = $val !== false ? $val['i'] ?? null : null;
-        return \is_int($read) ? $read & 0xFFFF_FFFF : 0;
+        if ($offset < 0 || $offset > $this->length - 4) {
+            $this->throwOutOfBounds($offset, 4);
+        }
+
+        return (\ord($this->str[$offset]) << 24)
+            | (\ord($this->str[$offset + 1]) << 16)
+            | (\ord($this->str[$offset + 2]) << 8)
+            | \ord($this->str[$offset + 3]);
     }
 
     /**
@@ -172,24 +201,59 @@ class Byte
      *
      * @return int 32 bit value
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getLong(int $offset): int
     {
-        $val = $this->getULong($offset);
-        // convert to signed 32-bit (two's complement)
+        if ($offset < 0 || $offset > $this->length - 4) {
+            $this->throwOutOfBounds($offset, 4);
+        }
+
+        // The uint32 value
+        $val = (\ord($this->str[$offset]) << 24)
+            | (\ord($this->str[$offset + 1]) << 16)
+            | (\ord($this->str[$offset + 2]) << 8)
+            | \ord($this->str[$offset + 3]);
+
+        // Use bitwise two's complement uint32 to int32 formula
         return ($val ^ 0x8000_0000) - 0x8000_0000;
     }
 
     /**
-     * Get FIXED from string (32-bit signed fixed-point number (16.16).
+     * Get FIXED from string (Big Endian 32-bit signed fixed-point number (16.16)).
+     *
+     * A fixed-point 16.16 number is 'int16 + uint16/65536.0' where the divisor 65536=(1<<16).
+     * A simplified equivalent version is to read an int32 and divide by 65536.
      *
      * @param int $offset Point from where to read the data.
      *
-     * @throws \RangeException if the requested read is out of bounds.
+     * @throws RangeException if the requested read is out of bounds.
      */
     public function getFixed(int $offset): float
     {
-        return (float) $this->getShort($offset) + ((float) $this->getUShort($offset + 2) / (float) 0x1_0000);
+        if ($offset < 0 || $offset > $this->length - 4) {
+            $this->throwOutOfBounds($offset, 4);
+        }
+
+        // The int16 integer part
+        $int16 = (((\ord($this->str[$offset]) << 8) | \ord($this->str[$offset + 1])) ^ 0x8000) - 0x8000;
+
+        // Add the uint16 fractional part
+        return $int16 + ((\ord($this->str[$offset + 2]) << 8) | \ord($this->str[$offset + 3])) / 65_536.0;
+    }
+
+    /**
+     * @param string $format
+     * @param string $string
+     * @param int $offset
+     *
+     * @return array<mixed>
+     *
+     * @throws FileException
+     */
+    public static function unpackOrThrow(string $format, string $string, int $offset = 0): array
+    {
+        $unpacked = \unpack($format, $string, $offset);
+        return $unpacked ? $unpacked: throw new FileException('Unable to unpack data');
     }
 }


### PR DESCRIPTION
Byte: Optimize read speed while minimizing memory usage by using direct string offsets and bitwise operators.

Improves read speed by ~40% by using '$str[$offset]' and bitwise operators compared to unpack(substr()). Slower than SplFixedArray with JIT, but that blew up on memory usage.

...


## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [ ] Testing.
