### PR TITLE
Make Cache work on Windows.

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -18,6 +18,9 @@ declare(strict_types=1);
 
 namespace Com\Tecnick\File;
 
+use Com\Tecnick\File\Exception as FileException;
+use Random\RandomException;
+
 /**
  * Com\Tecnick\Pdf\File\Cache
  *
@@ -35,9 +38,12 @@ namespace Com\Tecnick\File;
 class Cache
 {
     /**
+     * Whether this is a Windows machine
+     */
+    protected bool $isWindows;
+
+    /**
      * Cache path (per-instance)
-     *
-     * @var string
      */
     protected string $path = '';
 
@@ -50,17 +56,20 @@ class Cache
      * Set the file prefix (common name)
      *
      * @param ?string $prefix Common prefix to be used for all cache files
+     *
+     * @throws FileException
+     * @throws RandomException
      */
     public function __construct(?string $prefix = null)
     {
+        $this->isWindows = \PHP_OS_FAMILY === 'Windows';
+
         $this->defineSystemCachePath();
         $this->setCachePath();
-        if ($prefix === null) {
-            $prefix = \rtrim(
-                \base64_encode(\pack('H*', \md5(\uniqid((string) \mt_rand(0, \mt_getrandmax()), true)))),
-                '=',
-            );
-        }
+        $prefix ??= \rtrim(
+            \base64_encode(\pack('H*', \md5(\uniqid((string) \random_int(0, \PHP_INT_MAX), true)))),
+            '=',
+        );
 
         $safePrefix = \preg_replace('/[^a-zA-Z0-9_\-]/', '', \strtr($prefix, '+/', '-_')) ?? '';
         $this->prefix = '_' . $safePrefix . '_';
@@ -102,27 +111,80 @@ class Cache
      * Throws an exception when tempnam() fails, consistent with the rest of the library.
      *
      * @param string $type Type of file
-     * @param string $key  File key (used to retrieve file from cache)
+     * @param string $key File key (used to retrieve file from cache)
      *
      * @return string Temporary filename
      *
-     * @throws \Com\Tecnick\File\Exception when a temporary file cannot be created.
+     * @throws FileException
+     * @throws RandomException
      */
     public function getNewFileName(string $type = 'tmp', string $key = '0'): string
     {
-        $file = \tempnam($this->path, $this->prefix . $type . '_' . $key . '_');
-        if ($file === false) {
-            throw new Exception('unable to create a temporary file in: ' . $this->path);
+        if (!$this->isWindows) {
+            $file = \tempnam($this->path, $this->prefix . $type . '_' . $key . '_');
+            if ($file === false) {
+                throw new FileException('unable to create a temporary file in: ' . $this->path);
+            }
+            return $file;
         }
 
-        return $file;
+        // Windows: tempnam() truncates the prefix to 3 chars, collapsing the
+        // type/key keying. Reimplement with atomic create-exclusive instead.
+        return $this->createWindowsTempFile($type, $key);
     }
 
+    /**
+     * Returns a Windows specific temporary filename for caching files.
+     * Throws an exception when unable to create a temporary file,
+     * consistent with the rest of the library.
+     *
+     * @param string $type Type of file
+     * @param string $key File key (used to retrieve file from cache)
+     *
+     * @return string Temporary filename
+     *
+     * @throws FileException
+     * @throws RandomException
+     */
+    private function createWindowsTempFile(string $type = 'tmp', string $key = '0'): string
+    {
+        // Windows MAX_PATH is 260 incl. the NUL terminator, so the usable path
+        // length is 259. We budget for the full final name: $base + hex + ".tmp"
+        // This assumes non-long-path-aware PHP, which is the stock CLI default.
+        $maxPathLength = 259;
+        // suffix = '.tmp'
+        $suffixLength = 4;
+        // at least 1 random byte (2 hex characters)
+        $minHexLength = 2;
+
+        $base = $this->path . $this->prefix . "{$type}_{$key}_";
+
+        // Room left for the random hex segment after base + ".tmp".
+        $entropyBudget = $maxPathLength - \strlen($base) - $suffixLength;
+
+        if ($entropyBudget < $minHexLength) {
+            throw new FileException("Cache filepath exceeds maximum length of {$maxPathLength} on Windows.");
+        }
+
+        // Cap at 15 bytes (30 hex chars); use as much of the remaining budget as fits.
+        $numBytes = \max(1, \min(15, \intdiv($entropyBudget, 2)));
+
+        for ($attempt = 0; $attempt < 10; ++$attempt) {
+            $filepath = $base . \bin2hex(\random_bytes($numBytes)) . '.tmp';
+            $handle = @\fopen($filepath, 'x');
+            if ($handle !== false) {
+                \fclose($handle);
+                return $filepath;
+            }
+        }
+
+        throw new FileException("Unable to create a temporary file in: {$this->path}");
+    }
     /**
      * Delete cached files
      *
      * @param ?string $type Type of files to delete
-     * @param ?string $key  Specific file key to delete
+     * @param ?string $key Specific file key to delete
      */
     public function delete(?string $type = null, ?string $key = null): void
     {
@@ -137,13 +199,14 @@ class Cache
             }
         }
 
-        $path .= '*';
-        $files = \glob($path);
-        if ($files === [] || $files === false) {
+        $files = \glob($path . '*');
+        if (!$files) {
             return;
         }
 
-        \array_map('unlink', $files);
+        foreach ($files as $file) {
+            \unlink($file);
+        }
     }
 
     /**
@@ -178,7 +241,7 @@ class Cache
         }
 
         $kPathCache = \ini_get('upload_tmp_dir');
-        if ($kPathCache === false || $kPathCache === '') {
+        if (!$kPathCache) {
             $kPathCache = \sys_get_temp_dir();
         }
         \define('K_PATH_CACHE', $this->normalizePath($kPathCache));

--- a/src/Dir.php
+++ b/src/Dir.php
@@ -48,16 +48,16 @@ class Dir
                 $dir = '';
             }
 
-            if (\is_writable($dir . DIRECTORY_SEPARATOR . $name)) {
-                $dir = $dir . DIRECTORY_SEPARATOR . $name;
+            if (\is_writable($dir . \DIRECTORY_SEPARATOR . $name)) {
+                $dir .= \DIRECTORY_SEPARATOR . $name;
                 break;
             }
 
             $dir = \dirname($dir);
         }
 
-        if (\substr($dir, -1) !== DIRECTORY_SEPARATOR) {
-            $dir .= DIRECTORY_SEPARATOR;
+        if (\substr($dir, -1) !== \DIRECTORY_SEPARATOR) {
+            $dir .= \DIRECTORY_SEPARATOR;
         }
 
         return $dir;

--- a/test/CacheTest.php
+++ b/test/CacheTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * CacheTest.php
  *
@@ -16,6 +18,12 @@
 
 namespace Test;
 
+use Com\Tecnick\File\Cache;
+use Com\Tecnick\File\Exception as FileException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Random\RandomException;
+
 /**
  * Unit Test
  *
@@ -29,32 +37,62 @@ namespace Test;
  */
 class CacheTest extends TestUtil
 {
-    protected function getTestObject(): \Com\Tecnick\File\Cache
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    protected function getTestObject(string $prefix = '1_2-a+B/c'): Cache
     {
-        return new \Com\Tecnick\File\Cache('1_2-a+B/c');
+        return new Cache($prefix);
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
     public function testAutoPrefix(): void
     {
-        $cache = new \Com\Tecnick\File\Cache();
+        $cache = new Cache();
         $this->assertNotEmpty($cache->getFilePrefix());
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
     public function testGetCachePath(): void
     {
         $cache = $this->getTestObject();
         $cachePath = $cache->getCachePath();
-        $this->assertEquals('/', $cachePath[0]);
-        $this->assertEquals('/', \substr($cachePath, -1));
+
+        $systemRoot = \realpath('/');
+        if ($systemRoot === false) {
+            throw new FileException("Cannot find realpath of '/'");
+        }
+        $this->assertSame($systemRoot, \substr($cachePath, 0, \strlen($systemRoot)));
+        $this->assertSame('/', \substr($cachePath, -1));
 
         $cache->setCachePath();
         $this->assertEquals($cachePath, $cache->getCachePath());
 
-        $path = '/tmp';
+        // Test mandatory trailing slash added
+        $path = \sys_get_temp_dir();
         $cache->setCachePath($path);
-        $this->assertEquals('/tmp/', $cache->getCachePath());
+        $this->assertEquals($path . '/', $cache->getCachePath());
+
+        // Test mandatory trailing slash not added if already exists
+        $path .= '/';
+        $cache->setCachePath($path);
+        $this->assertEquals($path, $cache->getCachePath());
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
     public function testGetFilePrefix(): void
     {
         $cache = $this->getTestObject();
@@ -63,19 +101,33 @@ class CacheTest extends TestUtil
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
+    #[Test]
     public function testGetNewFileName(): void
     {
         $cache = $this->getTestObject();
+
+        // Test ability to get new file
         $val = $cache->getNewFileName('tst', '0123');
-        $this->bcAssertMatchesRegularExpression('/_1_2-a-B_c_tst_0123_/', $val);
         \unlink($val);
+
+        $this->assertNotFalse($val);
+        $this->assertMatchesRegularExpression('/_1_2-a-B_c_tst_0123_[0-9a-f]+\.tmp$/', $val);
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
     public function testNormalizePathInvalid(): void
     {
         $cache = $this->getTestObject();
+
+        $invalid = \sys_get_temp_dir() . '/nonexistent_' . \uniqid('', true);
+        $this->assertFalse(\file_exists($invalid), 'Sanity check: path should not exist');
 
         // invoke protected normalizePath via reflection so we can test
         // the branch where realpath() returns false
@@ -88,22 +140,133 @@ class CacheTest extends TestUtil
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
+    #[Test]
+    public function testExceptionWindowsTooLongFileName(): void
+    {
+        $reflectionClass = new \ReflectionClass(Cache::class);
+        $cache = $this->getTestObject('1_2-a+B/c');
+        $reflectionClass->getProperty('isWindows')->setValue($cache, true);
+
+        // Build a key with a final full path (base + "." + $fileType + minHex)
+        // exactly at the limit.  minHex is a minimum of 2 to represent 1 random byte in hex
+        $maxPathLen = 259;
+        $minHexLength = 2;
+
+        $cacheType = 'long';
+        $keyPlaceholder = '';
+        $winFileExtension = '.tmp';
+        // The full filename with a 0-character key (empty $keyPlaceholder)
+        $fixed = \strlen($cache->getCachePath() . $cache->getFilePrefix() . $cacheType . '_' . $keyPlaceholder . '_');
+        $maxKeyLength = $maxPathLen - $fixed - $minHexLength - \strlen($winFileExtension);
+
+        // Largest legal key succeeds.
+        $okFile = $cache->getNewFileName($cacheType, \str_repeat('x', $maxKeyLength));
+        $this->assertFileExists($okFile);
+        \unlink($okFile);
+
+        // One char longer throws.
+        $this->expectException(FileException::class);
+        $cache->getNewFileName($cacheType, \str_repeat('x', $maxKeyLength + 1));
+    }
+
+    /**
+     * @return array<string, array{0: bool}>
+     */
+    public static function provideIsWindows(): array
+    {
+        return [
+            'posix branch (tempnam)'      => [false],
+            'windows branch (reimplemented)' => [true],
+        ];
+    }
+
+    /**
+     * getNewFileName() must create the file on disk in BOTH branches,
+     * matching tempnam()'s contract.
+     *
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
+    #[DataProvider('provideIsWindows')]
+    public function testGetNewFileNameCreatesFile(bool $isWindows): void
+    {
+        $reflectionClass = new \ReflectionClass(Cache::class);
+        $cache = $this->getTestObject('ctest');
+        $reflectionClass->getProperty('isWindows')->setValue($cache, $isWindows);
+
+        $file = $cache->getNewFileName('tst', '0');
+
+        $this->assertFileExists($file, 'getNewFileName() must create the file, like tempnam()');
+        $this->assertSame('', \file_get_contents($file), 'A newly created cache file must be empty');
+
+        \unlink($file);
+    }
+
+    /**
+     * Repeated calls must return distinct, already-created files in BOTH
+     * branches. Because the file exists on return, a later call cannot be
+     * handed the same path — closing the race window between checking and
+     * file creation.
+     *
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
+    #[DataProvider('provideIsWindows')]
+    public function testGetNewFileNameReturnsUniqueExistingFiles(bool $isWindows): void
+    {
+        $reflectionClass = new \ReflectionClass(Cache::class);
+        $cache = $this->getTestObject('uniqtest');
+        $reflectionClass->getProperty('isWindows')->setValue($cache, $isWindows);
+
+        /** @var array<string, true> $seen */
+        $seen = [];
+        /** @var array<int, string> $created */
+        $created = [];
+
+        for ($i = 0; $i < 20; ++$i) {
+            $file = $cache->getNewFileName('uniq', '0');
+
+            $this->assertArrayNotHasKey($file, $seen, 'getNewFileName() returned a duplicate path');
+            $this->assertFileExists($file, 'Each returned path must already exist on disk');
+
+            $seen[$file] = true;
+            $created[] = $file;
+        }
+
+        foreach ($created as $file) {
+            \unlink($file);
+        }
+    }
+
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
     public function testDelete(): void
     {
         $cache = $this->getTestObject();
+
         $idk = 0;
         /** @var array<int, string> $file */
         $file = [];
         for ($idx = 1; $idx <= 2; ++$idx) {
             for ($idy = 1; $idy <= 2; ++$idy) {
                 $file[$idk] = $cache->getNewFileName((string) $idx, (string) $idy);
+                $this->assertNotFalse($file[$idk]);
                 \file_put_contents($file[$idk], '');
                 $this->assertTrue(\file_exists($file[$idk]));
                 ++$idk;
             }
         }
+
+        // Test deleting a non-existent cache item (for code coverage)
+        $cache->delete('5', '0');
 
         $f0 = $file[0] ?? '';
         $f1 = $file[1] ?? '';
@@ -112,12 +275,16 @@ class CacheTest extends TestUtil
 
         // delete a specific type/key pair
         $cache->delete('2', '1');
+        $this->assertNotFalse($f2);
         $this->assertFalse(\file_exists($f2));
 
         // delete all entries for type "1"
         $cache->delete('1');
+        $this->assertNotFalse($f0);
         $this->assertFalse(\file_exists($f0));
+        $this->assertNotFalse($f1);
         $this->assertFalse(\file_exists($f1));
+        $this->assertNotFalse($f3);
         $this->assertTrue(\file_exists($f3));
 
         // delete everything
@@ -126,12 +293,68 @@ class CacheTest extends TestUtil
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * delete()'s glob pattern must match the Windows reimplementation's
+     * naming scheme (prefix + type_key_ + hex + .tmp), not just tempnam's.
+     * Forcing isWindows lets Linux CI verify this branch.
+     *
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
+    public function testDeleteMatchesWindowsNamingScheme(): void
+    {
+        $reflectionClass = new \ReflectionClass(Cache::class);
+        $cache = $this->getTestObject('winfmt_' . \uniqid('', true));
+        $reflectionClass->getProperty('isWindows')->setValue($cache, true);
+
+        $keep   = $cache->getNewFileName('other', '1');
+        $target = $cache->getNewFileName('gone', '1');
+        $this->assertFileExists($keep);
+        $this->assertFileExists($target);
+
+        $cache->delete('gone', '1');
+
+        $this->assertFileDoesNotExist($target, 'delete() glob must match the .tmp/hex Windows naming');
+        $this->assertFileExists($keep, 'Unrelated Windows-named file must survive');
+
+        \unlink($keep);
+    }
+
+    /**
+     * deleteOlderThan() also globs by prefix, so it must likewise match the
+     * Windows reimplementation naming. Forced isWindows for Linux CI coverage.
+     *
+     * @throws FileException
+     * @throws RandomException
+     */
+    #[Test]
+    public function testDeleteOlderThanMatchesWindowsNamingScheme(): void
+    {
+        $reflectionClass = new \ReflectionClass(Cache::class);
+        $cache = $this->getTestObject('winttl_' . \uniqid('', true));
+        $reflectionClass->getProperty('isWindows')->setValue($cache, true);
+
+        $old   = $cache->getNewFileName('aged', '1');
+        $fresh = $cache->getNewFileName('aged', '2');
+        \touch($old, \time() - 7200);
+
+        $cache->deleteOlderThan(3600);
+
+        $this->assertFileDoesNotExist($old, 'Expired Windows-named file must be deleted');
+        $this->assertFileExists($fresh, 'Fresh Windows-named file must be kept');
+
+        \unlink($fresh);
+    }
+
+    /**
+     * @throws FileException
+     * @throws RandomException
      */
     public function testKeyOnlyDeletesAll(): void
     {
         $cache = $this->getTestObject();
         $file = $cache->getNewFileName('foo', 'bar');
+        $this->assertNotFalse($file);
         \file_put_contents($file, '');
         $this->assertTrue(\file_exists($file));
 
@@ -141,12 +364,14 @@ class CacheTest extends TestUtil
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
     public function testDeleteNonExistingPatterns(): void
     {
         $cache = $this->getTestObject();
         $file = $cache->getNewFileName('foo', 'bar');
+        $this->assertNotFalse($file);
         \file_put_contents($file, '');
         $this->assertTrue(\file_exists($file));
 
@@ -161,11 +386,15 @@ class CacheTest extends TestUtil
         \unlink($file);
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
     public function testEachInstanceHasOwnPrefix(): void
     {
         // Each instance should have its own prefix
-        $cache1 = new \Com\Tecnick\File\Cache('pfx1');
-        $cache2 = new \Com\Tecnick\File\Cache('pfx2');
+        $cache1 = new Cache('pfx1');
+        $cache2 = new Cache('pfx2');
 
         $prefix1 = $cache1->getFilePrefix();
         $prefix2 = $cache2->getFilePrefix();
@@ -176,15 +405,19 @@ class CacheTest extends TestUtil
         $this->assertStringContainsString('pfx2', $prefix2);
     }
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
     public function testEachInstanceHasOwnCachePath(): void
     {
-        $cache1 = new \Com\Tecnick\File\Cache();
+        $cache1 = new Cache();
         $path1 = $cache1->getCachePath();
 
         $tempdir = \sys_get_temp_dir() . '/cache_test_' . \uniqid();
         \mkdir($tempdir);
 
-        $cache2 = new \Com\Tecnick\File\Cache();
+        $cache2 = new Cache();
         $cache2->setCachePath($tempdir);
         $path2 = $cache2->getCachePath();
 
@@ -200,11 +433,12 @@ class CacheTest extends TestUtil
     // -------------------------------------------------------------------------
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
     public function testDeleteGlobCharsInTypeSanitised(): void
     {
-        $cache = new \Com\Tecnick\File\Cache('safepfx');
+        $cache = new Cache('safepfx');
 
         // Create a real file we do NOT want deleted.
         $real = $cache->getNewFileName('safe', '1');
@@ -222,11 +456,12 @@ class CacheTest extends TestUtil
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
     public function testDeleteGlobCharsInKeySanitised(): void
     {
-        $cache = new \Com\Tecnick\File\Cache('safepfx2');
+        $cache = new Cache('safepfx2');
 
         $real = $cache->getNewFileName('mytype', 'goodkey');
         \file_put_contents($real, '');
@@ -257,22 +492,27 @@ class CacheTest extends TestUtil
     // Issue 10: deleteOlderThan()
     // -------------------------------------------------------------------------
 
+    /**
+     * @throws FileException
+     * @throws RandomException
+     */
     public function testDeleteOlderThanNoFiles(): void
     {
         // Call deleteOlderThan() when no files exist for this cache prefix.
         // glob() returns [] so the early-return on line 171 is exercised.
-        $cache = new \Com\Tecnick\File\Cache('emptyprefix_' . \uniqid('', true));
+        $cache = new Cache('emptyprefix_' . \uniqid('', true));
         $cache->deleteOlderThan(3600);
         // No exception thrown is the expected outcome.
         $this->expectNotToPerformAssertions();
     }
 
     /**
-     * @throws \Com\Tecnick\File\Exception
+     * @throws FileException
+     * @throws RandomException
      */
     public function testDeleteOlderThan(): void
     {
-        $cache = new \Com\Tecnick\File\Cache('ttl');
+        $cache = new Cache('ttl');
 
         $old = $cache->getNewFileName('aged', '1');
         $fresh = $cache->getNewFileName('aged', '2');

--- a/test/DirTest.php
+++ b/test/DirTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * DirTest.php
  *
@@ -16,7 +18,9 @@
 
 namespace Test;
 
+use Com\Tecnick\File\Dir;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * File Color class test
@@ -31,11 +35,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class DirTest extends TestUtil
 {
-    protected function getTestObject(): \Com\Tecnick\File\Dir
+    protected function getTestObject(): Dir
     {
-        return new \Com\Tecnick\File\Dir();
+        return new Dir();
     }
 
+    #[Test]
     #[DataProvider('getAltFilePathsDataProvider')]
     public function testGetAltFilePaths(string $name, string $expected): void
     {
@@ -49,6 +54,15 @@ class DirTest extends TestUtil
      */
     public static function getAltFilePathsDataProvider(): array
     {
-        return [['', '/src/'], ['missing', '/'], ['src', '/src/']];
+        $paths = [['', '/src/'], ['missing', '/'], ['src', '/src/']];
+
+        // Handle Windows directory separators
+        if (\DIRECTORY_SEPARATOR !== '/') {
+            foreach ($paths as &$path) {
+                $path[1] = \str_replace('/', \preg_quote(\DIRECTORY_SEPARATOR, '#'), $path[1]);
+            }
+        }
+
+        return $paths;
     }
 }


### PR DESCRIPTION
On Windows, tempnam() truncates the prefix to 3 chars causing the per-type/key prefixes to truncate and loses its keying.  Add createWindowsTempFile using fopen's x mode to guarantee an empty file is created atomically as tempname does.

Honors Windows maximum path size of 259 characters and throws a File\Exception error if this would be exceeded.

Add tests to test Windows maximum path length and file creation as well as file deletion.

Fixes DirTest regex for windows directory separators.

## Checklist:

- [ ] The `make buildall` command has been run successfully without any error or warning.
- [ ] Any new code line is covered by unit tests and the coverage has not dropped.
- [ ] Any new code follows the style guidelines of this project.
- [ ] The code changes have been self-reviewed.
- [ ] Corresponding changes to the documentation have been made.
- [ ] The version has been updated in the VERSION file.

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue) → The patch number in the VERSION file has been increased.
- [ ] New feature (non-breaking change which adds functionality) → The minor number in the VERSION file has been increased.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) → The major number in the VERSION file has been increased.
- [ ] Automation.
- [ ] Documentation.
- [ ] Example.
- [X] Testing.
